### PR TITLE
Add extras bucket before installing scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ https://user-images.githubusercontent.com/11632726/178779071-ad5ca7da-0fc3-48c1-
 #### Scoop
 
 ```powershell
+scoop bucket add extras
 scoop install qrscan
 ```
 


### PR DESCRIPTION
Ensure the bucket is added before installing. Forgot to add this in the previous PR.